### PR TITLE
Correctly package logo file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "py4D_browser"
-version = "0.99999"
+version = "0.999995"
 authors = [
   { name="Steven Zeltmann", email="steven.zeltmann@lbl.gov" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,12 @@ py4DGUI = "py4D_browser.runGUI:launch"
 
 [tool.pyright]
 venv = "py4dstem"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+py4D_browser = ["*.png"]


### PR DESCRIPTION
This edits `pyproject.toml` to coax setuptools into correctly including the logo file, and minorly bumps the version