### PR TITLE
Persistent state, complex images, DPC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "py4D_browser"
-version = "1.1.4"
+version = "1.2.0"
 authors = [
   { name="Steven Zeltmann", email="steven.zeltmann@lbl.gov" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "py4D_browser"
-version = "1.1.3"
+version = "1.1.4"
 authors = [
   { name="Steven Zeltmann", email="steven.zeltmann@lbl.gov" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "h5py",
   "numpy >= 1.19",
   "matplotlib >= 3.2.2",
+  "platformdirs",
   "PyQt5 >= 5.10",
   "pyqtgraph >= 0.11",
   "sigfig",

--- a/src/py4D_browser/dialogs.py
+++ b/src/py4D_browser/dialogs.py
@@ -1,6 +1,7 @@
-from py4DSTEM import DataCube, data, tqdmnd
+from py4DSTEM import DataCube, data
 import pyqtgraph as pg
 import numpy as np
+from tqdm import tqdm
 from PyQt5.QtWidgets import QFrame, QPushButton, QApplication, QLabel
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtCore import Qt, QObject
@@ -428,8 +429,9 @@ class ManualTCBFDialog(QDialog):
         qy_operator = qy_operator * -2.0j * np.pi
 
         # loop over images and shift
-        for mx, my in tqdmnd(
-            *mask.shape,
+        img_indices = np.argwhere(mask)
+        for mx, my in tqdm(
+            img_indices,
             desc="Shifting images",
             file=StatusBarWriter(self.parent.statusBar()),
             mininterval=1.0,

--- a/src/py4D_browser/main_window.py
+++ b/src/py4D_browser/main_window.py
@@ -391,19 +391,11 @@ class DataViewer(QMainWindow):
         detector_mode_group.addAction(detector_maximum_action)
         self.detector_menu.addAction(detector_maximum_action)
 
-        detector_CoM_magnitude = QAction("CoM Ma&gnitude", self)
-        detector_CoM_magnitude.setCheckable(True)
-        detector_CoM_magnitude.triggered.connect(
-            partial(self.update_real_space_view, True)
-        )
-        detector_mode_group.addAction(detector_CoM_magnitude)
-        self.detector_menu.addAction(detector_CoM_magnitude)
-
-        detector_CoM_angle = QAction("CoM &Angle", self)
-        detector_CoM_angle.setCheckable(True)
-        detector_CoM_angle.triggered.connect(partial(self.update_real_space_view, True))
-        detector_mode_group.addAction(detector_CoM_angle)
-        self.detector_menu.addAction(detector_CoM_angle)
+        detector_CoM = QAction("C&oM", self)
+        detector_CoM.setCheckable(True)
+        detector_CoM.triggered.connect(partial(self.update_real_space_view, True))
+        detector_mode_group.addAction(detector_CoM)
+        self.detector_menu.addAction(detector_CoM)
 
         detector_iCoM = QAction("i&CoM", self)
         detector_iCoM.setCheckable(True)

--- a/src/py4D_browser/main_window.py
+++ b/src/py4D_browser/main_window.py
@@ -11,6 +11,7 @@ from PyQt5.QtWidgets import (
     QLabel,
     QToolTip,
     QPushButton,
+    QShortcut,
 )
 
 from matplotlib.backend_bases import tools
@@ -134,6 +135,7 @@ class DataViewer(QMainWindow):
         self.load_auto_action = QAction("&Load Data...", self)
         self.load_auto_action.triggered.connect(self.load_data_auto)
         self.file_menu.addAction(self.load_auto_action)
+        self.load_auto_action.setShortcut(QtGui.QKeySequence("Ctrl+O"))
 
         self.load_mmap_action = QAction("Load &Memory Map...", self)
         self.load_mmap_action.triggered.connect(self.load_data_mmap)
@@ -163,6 +165,8 @@ class DataViewer(QMainWindow):
         for method in ["Raw float32", "py4DSTEM HDF5", "Plain HDF5"]:
             menu_item = datacube_export_menu.addAction(method)
             menu_item.triggered.connect(partial(self.export_datacube, method))
+            if method == "py4DSTEM HDF5":
+                menu_item.setShortcut(QtGui.QKeySequence("Ctrl+S"))
 
         # Submenu to export virtual image
         vimg_export_menu = QMenu("Export Virtual Image", self)

--- a/src/py4D_browser/update_views.py
+++ b/src/py4D_browser/update_views.py
@@ -521,6 +521,7 @@ def update_diffraction_detector(self):
 
 def set_diffraction_autoscale_range(self, percentiles, redraw=True):
     self.diffraction_autoscale_percentiles = percentiles
+    self.settings.setValue("last_state/diffraction_autorange", list(percentiles))
 
     if redraw:
         self._render_diffraction_image(reset=False)
@@ -528,6 +529,7 @@ def set_diffraction_autoscale_range(self, percentiles, redraw=True):
 
 def set_real_space_autoscale_range(self, percentiles, redraw=True):
     self.real_space_autoscale_percentiles = percentiles
+    self.settings.setValue("last_state/realspace_autorange", list(percentiles))
 
     if redraw:
         self._render_virtual_image(reset=False)

--- a/src/py4D_browser/update_views.py
+++ b/src/py4D_browser/update_views.py
@@ -29,6 +29,7 @@ def update_real_space_view(self, reset=False):
     ], detector_mode
 
     # If a CoM method is checked, ensure linear scaling
+    scaling_mode = self.vimg_scaling_group.checkedAction().text().replace("&", "")
     if detector_mode in ["CoM Magnitude", "CoM Angle"] and scaling_mode != "Linear":
         print("Warning! Setting linear scaling for CoM image")
         self.vimg_scale_linear_action.setChecked(True)
@@ -383,7 +384,7 @@ def update_realspace_detector(self):
         return
 
     x, y = self.datacube.data.shape[:2]
-    x0, y0 = x / 2, y / 2
+    x0, y0 = x // 2, y // 2
     xr, yr = x / 10, y / 10
 
     # Remove existing detector
@@ -396,7 +397,10 @@ def update_realspace_detector(self):
 
     # Rectangular detector
     if detector_shape == "Point":
-        self.real_space_point_selector = pg_point_roi(self.real_space_widget.getView())
+        self.real_space_point_selector = pg_point_roi(
+            self.real_space_widget.getView(),
+            center=(x0 - 0.5, y0 - 0.5),
+        )
         self.real_space_point_selector.sigRegionChanged.connect(
             partial(self.update_diffraction_space_view, False)
         )
@@ -426,7 +430,7 @@ def update_diffraction_detector(self):
         return
 
     x, y = self.datacube.data.shape[2:]
-    x0, y0 = x / 2, y / 2
+    x0, y0 = x // 2, y // 2
     xr, yr = x / 10, y / 10
 
     # Remove existing detector
@@ -449,15 +453,17 @@ def update_diffraction_detector(self):
         )
         self.virtual_detector_roi_outer = None
 
-    # Rectangular detector
+    # Point detector
     if detector_shape == "Point":
         self.virtual_detector_point = pg_point_roi(
-            self.diffraction_space_widget.getView()
+            self.diffraction_space_widget.getView(),
+            center=(x0 - 0.5, y0 - 0.5),
         )
         self.virtual_detector_point.sigRegionChanged.connect(
             partial(self.update_real_space_view, False)
         )
 
+    # Rectangular detector
     elif detector_shape == "Rectangular":
         self.virtual_detector_roi = pg.RectROI(
             [int(x0 - xr / 2), int(y0 - yr / 2)], [int(xr), int(yr)], pen=(3, 9)

--- a/src/py4D_browser/update_views.py
+++ b/src/py4D_browser/update_views.py
@@ -7,7 +7,12 @@ from PyQt5 import QtCore
 from PyQt5.QtGui import QCursor
 import os
 
-from py4D_browser.utils import pg_point_roi, make_detector, complex_to_Lab
+from py4D_browser.utils import (
+    pg_point_roi,
+    make_detector,
+    complex_to_Lab,
+    StatusBarWriter,
+)
 
 
 def update_real_space_view(self, reset=False):
@@ -119,7 +124,12 @@ def update_real_space_view(self, reset=False):
             return
         mask = mask.astype(np.float32)
         vimg = np.zeros((self.datacube.R_Nx, self.datacube.R_Ny))
-        iterator = py4DSTEM.tqdmnd(self.datacube.R_Nx, self.datacube.R_Ny, disable=True)
+        iterator = py4DSTEM.tqdmnd(
+            self.datacube.R_Nx,
+            self.datacube.R_Ny,
+            file=StatusBarWriter(self.statusBar()),
+            mininterval=0.1,
+        )
 
         if detector_mode == "Integrating":
             for rx, ry in iterator:

--- a/src/py4D_browser/utils.py
+++ b/src/py4D_browser/utils.py
@@ -66,12 +66,12 @@ class LatchingButton(QPushButton):
                     self.status_bar.showMessage("Shift+click to keep on", 5_000)
 
 
-def pg_point_roi(view_box):
+def pg_point_roi(view_box, center=(-0.5, -0.5)):
     """
     Point selection.  Based in pyqtgraph, and returns a pyqtgraph CircleROI object.
     This object has a sigRegionChanged.connect() signal method to connect to other functions.
     """
-    circ_roi = pg.CircleROI((-0.5, -0.5), (2, 2), movable=True, pen=(0, 9))
+    circ_roi = pg.CircleROI(center, (2, 2), movable=True, pen=(0, 9))
     h = circ_roi.addTranslateHandle((0.5, 0.5))
     h.pen = pg.mkPen("r")
     h.update()


### PR DESCRIPTION
This adds some persistence of state across runs, currently maintaining the same window size and autorange settings. The data is stored in a platform-dependent location using a Qt settings INI file. 

This also removes the "CoM Magnitude" and "CoM Angle" detector response modes, and replaces them with a single "DPC" response that displays a Lab colored image representing magnitude and phase. To support this the virtual image can now be specified as a complex array, which triggers this new rendering mode. The data cursor changes to display magnitude and phase when hovering a complex image.

Detectors that require a mask (and thus loop over each pattern) now cause a progress bar to display in the status bar, since on some datasets these can be slow. 

Keyboard shortcuts are available for the vanilla loader and the py4DSTEM export: Ctrl+O and Ctrl+S

