### PR TITLE
Bugfix to require Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "py4D_browser"
-version = "1.3.0"
+version = "1.3.1"
 authors = [
   { name="Steven Zeltmann", email="steven.zeltmann@lbl.gov" },
 ]
 description = "A 4D-STEM data browser built on py4DSTEM."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",


### PR DESCRIPTION
The Plugins PR #30 uses features introduced in Python 3.11, so the minimum version needs to be increased in pyproject.toml